### PR TITLE
fix: convert yearly and quarterly subscription amounts to monthly for SUBS/MO stat

### DIFF
--- a/src/composables/__tests__/useFinances.test.ts
+++ b/src/composables/__tests__/useFinances.test.ts
@@ -66,6 +66,19 @@ describe('useFinances', () => {
     expect(totalSubsMonthly.value).toBe(175_000)
   })
 
+  it('converts yearly and quarterly subscriptions to monthly equivalent', async () => {
+    const subs: Subscription[] = [
+      { id: 1, name: 'Monthly', amount: 100_000, currency: 'IDR', cycle: 'monthly', next_date: '2026-04-15', color: '#fff', cancelled_at: null, created_at: '2026-01-01' },
+      { id: 2, name: 'Yearly', amount: 1_200_000, currency: 'IDR', cycle: 'yearly', next_date: '2026-04-20', color: '#fff', cancelled_at: null, created_at: '2026-01-01' },
+      { id: 3, name: 'Quarterly', amount: 300_000, currency: 'IDR', cycle: 'quarterly', next_date: '2026-04-20', color: '#fff', cancelled_at: null, created_at: '2026-01-01' },
+    ]
+
+    const { totalSubsMonthly } = await loadFinances([], [], subs)
+
+    // 100_000 + 1_200_000/12 + 300_000/3 = 100_000 + 100_000 + 100_000 = 300_000
+    expect(totalSubsMonthly.value).toBe(300_000)
+  })
+
   it('sorts subscriptions by next_date', async () => {
     const subs: Subscription[] = [
       { id: 1, name: 'Netflix', amount: 120_000, currency: 'IDR', cycle: 'monthly', next_date: '2026-04-20', color: '#fff', cancelled_at: null, created_at: '2026-01-01' },

--- a/src/composables/useFinances.ts
+++ b/src/composables/useFinances.ts
@@ -476,7 +476,12 @@ export function useFinances() {
   )
 
   const totalSubsMonthly = computed(() =>
-    activeSubscriptions.value.reduce((sum, subscription) => sum + (subscriptionAmountInBase(subscription) ?? 0), 0)
+    activeSubscriptions.value.reduce((sum, subscription) => {
+      const base = subscriptionAmountInBase(subscription) ?? 0
+      if (subscription.cycle === 'yearly') return sum + base / 12
+      if (subscription.cycle === 'quarterly') return sum + base / 3
+      return sum + base
+    }, 0)
   )
 
   const sortedSubscriptions = computed(() =>


### PR DESCRIPTION
## Summary
- Fixes the SUBS/MO dashboard stat and finances view subscription total to correctly normalize all billing cycles to a per-month equivalent
- Yearly subscriptions are divided by 12, quarterly by 3; monthly remains unchanged
- Adds a test covering mixed billing cycles

## Test plan
- [x] Add a monthly subscription (e.g. 100K IDR) — dashboard shows 100K subs/mo
- [x] Add a yearly subscription (e.g. 1200K IDR/yr) — dashboard now shows 200K subs/mo (was showing 1300K before)
- [x] Add a quarterly subscription (e.g. 300K IDR/qtr) — dashboard now shows 300K subs/mo
- [x] Run `pnpm test` — all tests pass

Closes #7