### PR TITLE
feat: add transfer between accounts

### DIFF
--- a/src/components/finances/TransferForm.vue
+++ b/src/components/finances/TransferForm.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import BaseModal from '../BaseModal.vue'
+import Select from '../Select.vue'
+import { useFinances } from '../../composables/useFinances'
+
+const props = defineProps<{
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  save: [data: { from_account_id: number; to_account_id: number; amount: number; date: string }]
+  close: []
+}>()
+
+const { accounts } = useFinances()
+
+const fromAccountId = ref<number | null>(null)
+const toAccountId = ref<number | null>(null)
+const amount = ref('')
+const date = ref('')
+
+const accountOptions = computed(() => accounts.value.map(account => ({
+  value: account.id,
+  label: account.name,
+})))
+
+const toAccountOptions = computed(() => accountOptions.value.map(option => ({
+  ...option,
+  disabled: option.value === fromAccountId.value,
+})))
+
+const canSave = computed(() => {
+  const numericAmount = Number(amount.value)
+  return !!fromAccountId.value && !!toAccountId.value && fromAccountId.value !== toAccountId.value && numericAmount > 0 && date.value.length > 0
+})
+
+watch(() => props.open, (open) => {
+  if (open) {
+    fromAccountId.value = accounts.value[0]?.id ?? null
+    toAccountId.value = accounts.value[1]?.id ?? null
+    amount.value = ''
+    date.value = new Date().toISOString().slice(0, 10)
+  }
+})
+
+watch(fromAccountId, (newVal) => {
+  if (toAccountId.value === newVal) {
+    toAccountId.value = accounts.value.find(a => a.id !== newVal)?.id ?? null
+  }
+})
+
+function handleSave() {
+  if (!canSave.value || !fromAccountId.value || !toAccountId.value) return
+  emit('save', {
+    from_account_id: fromAccountId.value,
+    to_account_id: toAccountId.value,
+    amount: Number(amount.value),
+    date: date.value,
+  })
+}
+</script>
+
+<template>
+  <BaseModal :open="open" width="min(520px, 96vw)" top="8%" @close="emit('close')">
+    <div class="tf-modal-inner" @keydown.ctrl.enter.prevent="handleSave" @keydown.meta.enter.prevent="handleSave">
+      <div class="tf-head">
+        <div class="tf-title">transfer</div>
+        <button type="button" class="b-close" @click="emit('close')">esc</button>
+      </div>
+
+      <div class="tf-field">
+        <label class="tf-label">from account</label>
+        <Select
+          v-model="fromAccountId"
+          :options="accountOptions"
+          placeholder="select account"
+        />
+      </div>
+
+      <div class="tf-field">
+        <label class="tf-label">to account</label>
+        <Select
+          v-model="toAccountId"
+          :options="toAccountOptions"
+          placeholder="select account"
+        />
+      </div>
+
+      <div class="tf-row">
+        <div class="tf-field">
+          <label class="tf-label">amount</label>
+          <input v-model="amount" type="number" min="0" step="0.01" class="tf-input tf-sm" />
+        </div>
+        <div class="tf-field">
+          <label class="tf-label">date</label>
+          <input v-model="date" type="date" class="tf-input tf-sm" />
+        </div>
+      </div>
+
+      <div class="tf-footer">
+        <button class="btn ghost" @click="emit('close')">cancel</button>
+        <button class="btn" :disabled="!canSave" @click="handleSave">transfer</button>
+      </div>
+    </div>
+  </BaseModal>
+</template>
+
+<style scoped>
+.tf-modal-inner {
+  padding: 16px;
+}
+
+.tf-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.tf-title {
+  font-family: var(--mono);
+  font-size: 0.9rem;
+}
+
+.tf-field {
+  margin-bottom: 10px;
+  flex: 1;
+}
+
+.tf-row {
+  display: flex;
+  gap: 10px;
+}
+
+.tf-label {
+  display: block;
+  font-size: 0.58rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 4px;
+}
+
+.tf-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  padding: 8px 10px;
+}
+
+.tf-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.tf-sm {
+  min-width: 0;
+}
+
+.tf-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+@media (max-width: 768px) {
+  .tf-row,
+  .tf-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/src/composables/useFinances.ts
+++ b/src/composables/useFinances.ts
@@ -300,6 +300,27 @@ export function useFinances() {
     await refreshSnapshot(existing?.date || toISO(new Date()))
   }
 
+  async function createTransfer(input: { from_account_id: number; to_account_id: number; amount: number; date: string }) {
+    const fromAccount = accounts.value.find(a => a.id === input.from_account_id)
+    const toAccount = accounts.value.find(a => a.id === input.to_account_id)
+    await createTransaction({
+      account_id: input.from_account_id,
+      description: `transfer to ${toAccount?.name ?? 'account'}`,
+      amount: input.amount,
+      type: 'expense',
+      date: input.date,
+      category_id: null,
+    })
+    await createTransaction({
+      account_id: input.to_account_id,
+      description: `transfer from ${fromAccount?.name ?? 'account'}`,
+      amount: input.amount,
+      type: 'income',
+      date: input.date,
+      category_id: null,
+    })
+  }
+
   async function createTransactionCategory(input: TransactionCategoryInput) {
     const db = await getDb()
     const nextSort = transactionCategories.value.filter(category => category.kind === input.kind).length
@@ -556,6 +577,7 @@ export function useFinances() {
     createTransaction,
     updateTransaction,
     deleteTransaction,
+    createTransfer,
     createTransactionCategory,
     updateTransactionCategory,
     deleteTransactionCategory,

--- a/src/views/FinancesView.vue
+++ b/src/views/FinancesView.vue
@@ -8,6 +8,7 @@ import SubscriptionRow from '../components/finances/SubscriptionRow.vue'
 import TransactionRow from '../components/finances/TransactionRow.vue'
 import AccountForm from '../components/finances/AccountForm.vue'
 import TransactionForm from '../components/finances/TransactionForm.vue'
+import TransferForm from '../components/finances/TransferForm.vue'
 import SubscriptionForm from '../components/finances/SubscriptionForm.vue'
 import TransactionCategoryForm from '../components/finances/TransactionCategoryForm.vue'
 import ExchangeRateForm from '../components/finances/ExchangeRateForm.vue'
@@ -36,6 +37,7 @@ const {
   createTransaction,
   updateTransaction,
   deleteTransaction,
+  createTransfer,
   createSubscription,
   updateSubscription,
   cancelSubscription,
@@ -56,6 +58,7 @@ const activeTab = ref<FinanceTab>('main')
 
 const accountFormOpen = ref(false)
 const transactionFormOpen = ref(false)
+const transferFormOpen = ref(false)
 const subscriptionFormOpen = ref(false)
 const categoryFormOpen = ref(false)
 const rateFormOpen = ref(false)
@@ -102,6 +105,7 @@ const selectedAccountCurrentBalance = computed(() =>
 function closeAllForms() {
   accountFormOpen.value = false
   transactionFormOpen.value = false
+  transferFormOpen.value = false
   subscriptionFormOpen.value = false
   categoryFormOpen.value = false
   rateFormOpen.value = false
@@ -140,6 +144,11 @@ async function saveTransaction(data: {
   } else {
     await createTransaction(data)
   }
+  closeAllForms()
+}
+
+async function handleTransfer(data: { from_account_id: number; to_account_id: number; amount: number; date: string }) {
+  await createTransfer(data)
   closeAllForms()
 }
 
@@ -210,6 +219,7 @@ function updateBaseCurrency(value: string | number | null) {
               <span v-if="selectedAccountIds.length" class="simple-sub">{{ selectedAccountIds.length }} selected</span>
               <button class="mini-btn" @click="selectedAccount = null; accountFormOpen = true">new account</button>
               <button class="mini-btn" @click="selectedTransaction = null; transactionFormOpen = true">new tx</button>
+              <button class="mini-btn" @click="transferFormOpen = true">transfer</button>
             </div>
           </div>
           <div class="accounts-grid">
@@ -321,6 +331,12 @@ function updateBaseCurrency(value: string | number | null) {
         :transaction="selectedTransaction"
         @save="saveTransaction"
         @delete="id => deleteTransaction(id).then(closeAllForms)"
+        @close="closeAllForms"
+      />
+
+      <TransferForm
+        :open="transferFormOpen"
+        @save="handleTransfer"
         @close="closeAllForms"
       />
 


### PR DESCRIPTION
## Summary
- Adds a "transfer" button next to "new tx" in the accounts & transactions section
- Opens a `TransferForm` modal with source account, destination account, amount, and date fields
- On submit, creates a paired expense transaction on the source account and an income transaction on the destination account (descriptions: "transfer to [name]" / "transfer from [name]")
- Adds `createTransfer` function to `useFinances` composable

## Test plan
- [x] Click "transfer" button in finances — modal opens
- [x] Select source and destination accounts, enter amount and date, click transfer
- [x] Verify two transactions are created: expense on source, income on destination
- [x] Verify source account cannot be selected as destination (disabled in dropdown)
- [x] Run `pnpm test` and `vue-tsc --noEmit` — all pass

Closes #10