### PR TITLE
feat: support linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,70 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libglib2.0-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev libappindicator3-dev librsvg2-dev
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libgtk-3-dev \
+            libglib2.0-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            build-essential \
+            curl wget file
 
       - run: cargo check
         working-directory: src-tauri
+
+  build-linux:
+    name: Build Linux Bundles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libgtk-3-dev \
+            libglib2.0-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            build-essential \
+            curl wget file xdg-utils
+
+      - run: pnpm install
+
+      # deb and rpm are bundled without downloading extra tooling, so they keep
+      # this job hermetic while still proving the Linux packaging path works.
+      - run: pnpm tauri build --bundles deb,rpm
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slowlife-linux-bundles
+          path: |
+            src-tauri/target/release/bundle/deb/*.deb
+            src-tauri/target/release/bundle/rpm/*.rpm
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ Thanks for your interest in contributing. This document covers the essentials.
 - [Rust](https://www.rust-lang.org/tools/install) (stable toolchain)
 - Tauri v2 system dependencies — see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
 
+On Linux, install the system packages listed under
+[Linux system dependencies](README.md#linux-system-dependencies) in the README before
+running `pnpm tauri:dev`.
+
 ## Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ slowlife is a desktop-first journaling, todos, scheduling, and financial trackin
 - **Sidebar-free**: sidebar and FAB are hidden; exit via Esc or the exit button
 
 ### Desktop Experience
+- **Platforms**: macOS and Linux (X11 and Wayland)
 - **Runtime**: native app via Tauri
 - **Database**: local SQLite
 - **Command palette**: Ctrl+K for global search and navigation
 - **Shortcuts**: navigation, quick capture (Ctrl+N), focus mode (Ctrl+0), sidebar toggle (Ctrl+S)
 - **Sidebar toggle**: collapsible on desktop, overlay on mobile
-- **System tray**: supported
+- **System tray**: closing the window hides it to the tray; the tray menu reopens it, triggers quick capture, or quits
 
 ## Roadmap Preview
 
@@ -114,6 +115,35 @@ See [ROADMAP.md](ROADMAP.md) for the full roadmap. Key upcoming milestones:
 - [Rust](https://www.rust-lang.org/tools/install) (stable)
 - Tauri v2 system dependencies — see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
 
+#### Linux system dependencies
+
+Debian / Ubuntu:
+
+```bash
+sudo apt update
+sudo apt install libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev \
+  libgtk-3-dev libglib2.0-dev libayatana-appindicator3-dev librsvg2-dev \
+  libxdo-dev libssl-dev build-essential curl wget file xdg-utils
+```
+
+Fedora:
+
+```bash
+sudo dnf install webkit2gtk4.1-devel javascriptcoregtk4.1-devel libsoup3-devel \
+  gtk3-devel libappindicator-gtk3-devel librsvg2-devel libxdo-devel openssl-devel \
+  xdg-utils @development-tools
+```
+
+Arch:
+
+```bash
+sudo pacman -S webkit2gtk-4.1 libsoup3 gtk3 libayatana-appindicator librsvg \
+  xdotool openssl base-devel xdg-utils
+```
+
+`libayatana-appindicator` (or its equivalent) is what backs the system tray, and
+`xdg-utils` is required to bundle an AppImage.
+
 ### Setup
 
 ```bash
@@ -140,6 +170,28 @@ Dev and production are intentionally isolated:
 ```bash
 pnpm tauri build
 ```
+
+`pnpm tauri build` produces bundles for the host platform:
+
+| Platform | Output |
+|----------|--------|
+| macOS | `.app`, `.dmg` |
+| Linux | `.deb`, `.rpm`, `.AppImage` |
+
+Bundles land in `src-tauri/target/release/bundle/`. Limit the formats with
+`--bundles`, for example `pnpm tauri build --bundles deb`.
+
+### Linux notes
+
+- **System tray**: GNOME does not show tray icons out of the box — install the
+  [AppIndicator extension](https://extensions.gnome.org/extension/615/appindicator-support/).
+  Most other desktops (KDE, XFCE, Cinnamon) work without extra setup.
+- **Global shortcuts**: quick capture (`Alt+Shift+C`) and `Ctrl+Shift+J` are grabbed
+  through X11. If another application already owns a combination, or the session is
+  Wayland-native without XWayland, that shortcut is skipped with a warning on stderr
+  and the rest of the app runs normally.
+- **Data location**: the SQLite database lives under `~/.config/com.addeeandra.slowlife/`
+  (`com.addeeandra.slowlife.dev` for dev builds).
 
 ## Contributing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 ## Local Dev Release
 
-For small-community macOS prereleases, use the local `./local-release` script instead of CI.
+For small-community prereleases, use the local `./local-release` script instead of CI.
+It runs on macOS and Linux and bundles for whichever platform you run it on.
 
 ```bash
 ./local-release v0.0.1-dev
@@ -10,7 +11,28 @@ For small-community macOS prereleases, use the local `./local-release` script in
 
 - Tags must match `vX.Y.Z-dev`
 - The script updates `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml` to `X.Y.Z`
-- Build-only mode creates the local `.dmg` and leaves version edits in your working tree
-- `--push` creates a git tag, pushes it, creates a GitHub prerelease, and uploads the `.dmg`
+- Build-only mode creates the local bundles and leaves version edits in your working tree
+- `--push` creates a git tag, pushes it, creates a GitHub prerelease, and uploads every bundle it finds
 - `--auto` only works with `--push` and auto-commits managed version changes when the dirty state is limited to the release version files
 - These `-dev` releases are not notarized yet, so macOS may require manual approval on first open
+
+### Bundles per platform
+
+| Host | Uploaded artifacts |
+|------|--------------------|
+| macOS | `.dmg` |
+| Linux | `.deb`, `.rpm`, `.AppImage` |
+
+Because a run only bundles for its host, publishing both macOS and Linux artifacts under
+one tag means running the script on macOS first and attaching the Linux bundles to the
+existing release afterwards:
+
+```bash
+gh release upload v0.0.1-dev \
+  src-tauri/target/release/bundle/deb/*.deb \
+  src-tauri/target/release/bundle/rpm/*.rpm \
+  src-tauri/target/release/bundle/appimage/*.AppImage
+```
+
+AppImage bundling downloads `linuxdeploy` tooling on first run, so that step needs network
+access and `xdg-utils` installed.

--- a/local-release
+++ b/local-release
@@ -1,21 +1,22 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 
 set -euo pipefail
 
-SCRIPT_DIR=${0:A:h}
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$SCRIPT_DIR"
 PACKAGE_JSON="$REPO_ROOT/package.json"
 TAURI_CONFIG="$REPO_ROOT/src-tauri/tauri.conf.json"
 CARGO_TOML="$REPO_ROOT/src-tauri/Cargo.toml"
-DMG_DIR="$REPO_ROOT/src-tauri/target/release/bundle/dmg"
-RELEASE_NOTES=$'Development build for early testers.\n\nThis build is not notarized yet, so macOS may block it on first open. If that happens, right-click the app and choose Open, or allow it in Privacy & Security.'
+BUNDLE_DIR="$REPO_ROOT/src-tauri/target/release/bundle"
+RELEASE_NOTES=$'Development build for early testers.\n\nmacOS: this build is not notarized yet, so macOS may block it on first open. If that happens, right-click the app and choose Open, or allow it in Privacy & Security.\n\nLinux: install the .deb (Debian/Ubuntu) or .rpm (Fedora/openSUSE), or mark the .AppImage executable and run it directly.'
 
 TAG=""
 VERSION=""
 DO_PUSH=0
 AUTO_COMMIT=0
 AUTO_COMMIT_CREATED=0
-DMG_PATH=""
+PLATFORM=""
+ARTIFACTS=()
 
 usage() {
   cat <<'EOF'
@@ -25,19 +26,22 @@ Usage:
   ./local-release v0.0.1-dev --push --auto
 
 Options:
-  --push   Create git tag, push it, create a GitHub prerelease, and upload the DMG
+  --push   Create git tag, push it, create a GitHub prerelease, and upload the bundles
   --auto   With --push, auto-commit managed release version changes if needed
+
+Bundles are produced for the host platform only:
+  macOS   .dmg
+  Linux   .deb, .rpm, .AppImage
 EOF
 }
 
 fail() {
-  print -u2 -- "$1"
+  printf '%s\n' "$1" >&2
   exit 1
 }
 
 require_cmd() {
-  local cmd="$1"
-  command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
 }
 
 confirm() {
@@ -88,12 +92,22 @@ parse_args() {
 }
 
 validate_tag() {
-  [[ "$TAG" =~ '^v([0-9]+\.[0-9]+\.[0-9]+)-dev$' ]] || fail "Tag must match vX.Y.Z-dev"
-  VERSION="${match[1]}"
+  [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-dev$ ]] || fail "Tag must match vX.Y.Z-dev"
+  VERSION="${BASH_REMATCH[1]}"
 }
 
-check_platform() {
-  [[ "$(uname -s)" == "Darwin" ]] || fail "local-release only supports macOS"
+detect_platform() {
+  case "$(uname -s)" in
+    Darwin)
+      PLATFORM="macos"
+      ;;
+    Linux)
+      PLATFORM="linux"
+      ;;
+    *)
+      fail "local-release supports macOS and Linux only"
+      ;;
+  esac
 }
 
 check_requirements() {
@@ -150,33 +164,37 @@ build_release() {
   (cd "$REPO_ROOT" && pnpm tauri build)
 }
 
-find_dmg() {
-  [[ -d "$DMG_DIR" ]] || fail "DMG output directory not found: $DMG_DIR"
+collect_artifacts() {
+  local patterns=()
 
-  local dmg_files
-  dmg_files=("$DMG_DIR"/*.dmg(N))
+  if [[ "$PLATFORM" == "macos" ]]; then
+    patterns=("$BUNDLE_DIR/dmg"/*.dmg)
+  else
+    patterns=(
+      "$BUNDLE_DIR/deb"/*.deb
+      "$BUNDLE_DIR/rpm"/*.rpm
+      "$BUNDLE_DIR/appimage"/*.AppImage
+    )
+  fi
 
-  [[ ${#dmg_files[@]} -gt 0 ]] || fail "No DMG artifact found in $DMG_DIR"
+  ARTIFACTS=()
 
-  DMG_PATH="${dmg_files[1]}"
+  local candidate
+  for candidate in "${patterns[@]}"; do
+    [[ -f "$candidate" ]] && ARTIFACTS+=("$candidate")
+  done
+
+  [[ ${#ARTIFACTS[@]} -gt 0 ]] || fail "No release artifacts found under $BUNDLE_DIR"
 }
 
 print_dirty_status() {
   git -C "$REPO_ROOT" status --short
 }
 
-collect_dirty_files() {
-  git -C "$REPO_ROOT" status --porcelain | awk '{print $2}'
-}
-
+# Avoids mapfile so the script still runs on the bash 3.2 that ships with macOS.
 contains_only_managed_dirty_files() {
-  local files
-  files=(${(@f)$(collect_dirty_files)})
-
-  [[ ${#files[@]} -gt 0 ]] || return 0
-
   local file
-  for file in "${files[@]}"; do
+  while IFS= read -r file; do
     case "$file" in
       package.json|src-tauri/tauri.conf.json|src-tauri/Cargo.toml)
         ;;
@@ -184,7 +202,7 @@ contains_only_managed_dirty_files() {
         return 1
         ;;
     esac
-  done
+  done < <(git -C "$REPO_ROOT" status --porcelain | cut -c4-)
 
   return 0
 }
@@ -194,7 +212,7 @@ handle_dirty_tree_for_push() {
     return
   fi
 
-  print "Working tree has uncommitted changes:"
+  printf '%s\n' "Working tree has uncommitted changes:"
   print_dirty_status
 
   if [[ $AUTO_COMMIT -eq 1 ]]; then
@@ -220,13 +238,20 @@ create_and_push_tag() {
 }
 
 create_github_release() {
-  (cd "$REPO_ROOT" && gh release create "$TAG" "$DMG_PATH" --prerelease --title "$TAG" --notes "$RELEASE_NOTES")
+  (cd "$REPO_ROOT" && gh release create "$TAG" "${ARTIFACTS[@]}" --prerelease --title "$TAG" --notes "$RELEASE_NOTES")
+}
+
+print_artifacts() {
+  local artifact
+  for artifact in "${ARTIFACTS[@]}"; do
+    printf -- 'Built artifact: %s\n' "$artifact"
+  done
 }
 
 main() {
   parse_args "$@"
   validate_tag
-  check_platform
+  detect_platform
   check_requirements
 
   if [[ $DO_PUSH -eq 1 ]]; then
@@ -236,10 +261,10 @@ main() {
 
   update_versions
   build_release
-  find_dmg
+  collect_artifacts
 
   if [[ $DO_PUSH -eq 0 ]]; then
-    print -- "Built DMG: $DMG_PATH"
+    print_artifacts
     exit 0
   fi
 
@@ -249,8 +274,8 @@ main() {
   local release_url
   release_url=$(create_github_release)
 
-  print -- "Built DMG: $DMG_PATH"
-  print -- "Release URL: $release_url"
+  print_artifacts
+  printf -- 'Release URL: %s\n' "$release_url"
 }
 
 main "$@"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -213,30 +213,135 @@ async fn start_google_oauth(app: tauri::AppHandle, auth_url: String) -> Result<O
     Ok(OAuthStartResponse { auth_url, redirect_uri })
 }
 
+/// Shortcuts are registered at runtime instead of through the plugin builder so a
+/// rejected combination cannot take the whole app down. On Linux the X11 grab fails
+/// when another application already owns the combination, and Wayland sessions can
+/// refuse it outright.
+#[cfg(desktop)]
+const GLOBAL_SHORTCUTS: [&str; 2] = ["alt+shift+c", "cmdorcontrol+shift+j"];
+
+#[cfg(desktop)]
+fn reveal_main_window(app: &tauri::AppHandle) {
+    use tauri::Manager;
+
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+#[cfg(desktop)]
+fn register_global_shortcuts(app: &tauri::AppHandle) {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+    for shortcut in GLOBAL_SHORTCUTS {
+        if let Err(error) = app.global_shortcut().register(shortcut) {
+            eprintln!("slowlife: global shortcut {shortcut} unavailable: {error}");
+        }
+    }
+}
+
+#[cfg(desktop)]
+fn setup_close_to_tray(window: tauri::WebviewWindow) {
+    use tauri::WindowEvent;
+
+    window.clone().on_window_event(move |event| {
+        // reference: https://github.com/tauri-apps/tauri/issues/10580#issuecomment-2816902942
+        if let WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_close();
+
+            #[cfg(target_os = "macos")]
+            {
+                use tauri::Manager;
+
+                if matches!(window.is_fullscreen(), Ok(true)) {
+                    let app_handle = window.app_handle().clone();
+                    let window_label = window.label().to_string();
+
+                    let _ = window.set_fullscreen(false);
+
+                    tauri::async_runtime::spawn(async move {
+                        std::thread::sleep(std::time::Duration::from_millis(700));
+                        if let Some(win) = app_handle.get_webview_window(&window_label) {
+                            let _ = win.hide();
+                        }
+                    });
+
+                    return;
+                }
+            }
+
+            let _ = window.hide();
+        }
+    });
+}
+
+#[cfg(desktop)]
+fn setup_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
+    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
+    use tauri::tray::{TrayIconBuilder, TrayIconEvent};
+    use tauri::Emitter;
+
+    // Linux tray implementations report clicks inconsistently, so every tray action
+    // is reachable from the menu as well.
+    let open_item = MenuItem::with_id(app, "open", "Open slowlife", true, None::<&str>)?;
+    let capture_item = MenuItem::with_id(app, "quick-capture", "Quick capture", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, "quit", "Quit slowlife", true, None::<&str>)?;
+    let menu = Menu::with_items(
+        app,
+        &[
+            &open_item,
+            &capture_item,
+            &PredefinedMenuItem::separator(app)?,
+            &quit_item,
+        ],
+    )?;
+
+    TrayIconBuilder::new()
+        .menu(&menu)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "open" => reveal_main_window(app),
+            "quick-capture" => {
+                let _ = app.emit("quick-capture", ());
+                reveal_main_window(app);
+            }
+            "quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(move |tray, event| {
+            if let TrayIconEvent::Click { .. } = event {
+                let app = tray.app_handle();
+                let _ = app.emit("quick-capture", ());
+                reveal_main_window(app);
+            }
+        })
+        .icon(
+            app.default_window_icon()
+                .cloned()
+                .expect("missing default window icon"),
+        )
+        .show_menu_on_left_click(false)
+        .build(app)?;
+
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    use tauri::Emitter;
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![start_google_oauth])
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_sql::Builder::new().build())
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
-                .with_shortcuts(["alt+shift+c", "cmdorcontrol+shift+j"])
-                .expect("failed to register global shortcuts")
                 .with_handler(|app, _shortcut, event| {
                     use tauri::Emitter;
                     use tauri_plugin_global_shortcut::ShortcutState;
                     if event.state == ShortcutState::Pressed {
                         let _ = app.emit("quick-capture", ());
                         #[cfg(desktop)]
-                        {
-                            use tauri::Manager;
-                            if let Some(window) = app.get_webview_window("main") {
-                                let _ = window.show();
-                                let _ = window.set_focus();
-                            }
-                        }
+                        reveal_main_window(app);
                     }
                 })
                 .build(),
@@ -245,58 +350,16 @@ pub fn run() {
             #[cfg(desktop)]
             {
                 use tauri::Manager;
-                use tauri::tray::{TrayIconBuilder, TrayIconEvent};
-                use tauri::WindowEvent;
 
                 let app_handle = app.handle();
+
+                register_global_shortcuts(app_handle);
+
                 if let Some(main_window) = app_handle.get_webview_window("main") {
-                    main_window.clone().on_window_event(move |event| {
-                        // reference: https://github.com/tauri-apps/tauri/issues/10580#issuecomment-2816902942
-                        if let WindowEvent::CloseRequested { api, .. } = event {
-                            api.prevent_close();
-                            #[cfg(target_os = "macos")]
-                            {
-                                match main_window.is_fullscreen() {
-                                    Ok(true) => {
-                                        let app_handle = main_window.app_handle().clone();
-                                        let window_label = main_window.label().to_string();
-
-                                        let _ = main_window.set_fullscreen(false);
-
-                                        tauri::async_runtime::spawn(async move {
-                                            std::thread::sleep(std::time::Duration::from_millis(700));
-                                            if let Some(win) = app_handle.get_webview_window(&window_label) {
-                                                win.hide().unwrap();
-                                            }
-                                        });
-                                    }
-                                    _ => {
-                                        main_window.hide().unwrap();
-                                    }
-                                }
-                            }
-                        }
-                    });
+                    setup_close_to_tray(main_window);
                 }
 
-                TrayIconBuilder::new()
-                    .on_tray_icon_event(move |tray, event| {
-                        if let TrayIconEvent::Click { .. } = event {
-                            let _ = tray.app_handle().emit("quick-capture", ());
-                            if let Some(window) = tray.app_handle().get_webview_window("main") {
-                                let _ = window.show();
-                                let _ = window.set_focus();
-                            }
-                        }
-                    })
-                    .icon(
-                        app_handle
-                            .default_window_icon()
-                            .cloned()
-                            .expect("missing default window icon"),
-                    )
-                    .show_menu_on_left_click(false)
-                    .build(app)?;
+                setup_tray(app_handle)?;
             }
             Ok(())
         })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,10 @@
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
-      "icons/icon.ico"
-    ]
+      "icons/icon.ico",
+      "icons/icon.png"
+    ],
+    "category": "Productivity",
+    "shortDescription": "slowlife — your pace, your space"
   }
 }

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -32,7 +32,10 @@
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
-      "icons/icon.ico"
-    ]
+      "icons/icon.ico",
+      "icons/icon.png"
+    ],
+    "category": "Productivity",
+    "shortDescription": "slowlife — your pace, your space"
   }
 }


### PR DESCRIPTION
Linux was never a working target: closing the window prevented the close
without ever hiding it, so the window could not be dismissed anywhere
outside macOS, and the tray had no menu to bring it back. Global shortcut
registration also panicked the whole app when a combination was rejected,
which happens routinely on Linux when another application owns the
combination or the session is Wayland-native.

- hide the window to the tray on every desktop platform, keeping the
  macOS fullscreen dance intact
- add a tray menu (open / quick capture / quit) since Linux tray
  implementations report clicks inconsistently
- register global shortcuts at runtime and warn instead of panicking when
  one is unavailable
- unminimize when revealing the window so a minimized window comes back
- set bundle category and short description so the generated .desktop
  entry carries Categories and Comment, and ship the 512px icon
- add a CI job that builds the .deb and .rpm bundles, and correct the
  Linux dependency list (libayatana-appindicator3-dev, libxdo-dev)
- rewrite local-release in portable bash (it was zsh-only and refused to
  run off macOS) and collect .deb/.rpm/.AppImage on Linux
- document Linux prerequisites, bundle outputs, and tray/shortcut caveats

Verified on Linux: cargo check, .deb, .rpm and .AppImage bundles all
build, and the generated .deb carries the correct dependencies.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RRogfeHEE6VpR7UfACmFB3